### PR TITLE
Add support for fast read and whole scan option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb33622da908807a06f9513c19b3c1ad50fab3e4137d82a78107d502075aa199"
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,18 +1285,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1544,9 +1550,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1581,12 +1587,14 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "bimap",
+ "bzip2",
  "chrono",
  "clap",
  "csv",
  "digest",
  "env_logger",
  "flate2",
+ "infer",
  "lazy_static",
  "log",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+infer = { version = "0.15.0", default-features = false }
 clap = { version = "4.4.18", features = ["derive"] }
 nom = "7.1.3"
 noodles = { version = "0.60.0", features = [
@@ -40,6 +41,7 @@ chrono = "0.4.31"
 lazy_static = "1.4.0"
 bimap = "0.6.3"
 openssl = { version = "0.10.63", features = ["vendored"] }
+bzip2 = "0.4.4"
 
 [dev-dependencies]
 assert_cmd = "2.0.13"

--- a/src/args.rs
+++ b/src/args.rs
@@ -45,6 +45,18 @@ pub struct Args {
     #[clap(short, long, value_name = "FILE")]
     pub conf: Option<PathBuf>,
 
+    /// Attempt to read the whole lines from the input files.
+    #[clap(long, conflicts_with_all = ["num_lines"])]
+    pub tidy: bool,
+
+    /// Do not try to decompress the input file when detecting the file format.
+    #[clap(long)]
+    pub no_decompress: bool,
+
+    /// Number of lines to read from the input file. Ignored when `--tidy` is provided.
+    #[clap(short, long, default_value = "10000")]
+    pub num_lines: usize,
+
     /// Output the configuration file in yaml format and exit the program. If `--conf` option is not provided, the default configuration file will be shown.
     #[clap(long)]
     pub dry_run: bool,

--- a/src/buffered_read_seek.rs
+++ b/src/buffered_read_seek.rs
@@ -1,0 +1,128 @@
+use anyhow::Result;
+use flate2::read::{GzDecoder, ZlibDecoder};
+use std::io::{self, Cursor, Read, Seek, SeekFrom};
+
+pub struct OnetimeRewindableReader<R: Read> {
+    inner: R,
+    buffer: Option<Cursor<Vec<u8>>>,
+    has_rewound: bool,
+}
+
+impl<R: Read> OnetimeRewindableReader<R> {
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner,
+            buffer: None,
+            has_rewound: false,
+        }
+    }
+}
+
+impl<R: Read> Read for OnetimeRewindableReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if let Some(ref mut buffer) = self.buffer {
+            // 既にバッファがある場合はそこから読み取る
+            let count = buffer.read(buf)?;
+            if count == 0 {
+                // バッファが空になった場合は、元の入力から読み取る
+                let innercount = self.inner.read(buf);
+                innercount
+            } else {
+                Ok(count)
+            }
+        } else {
+            // 初回の読み取りでバッファを準備
+            let mut temp_buffer = vec![0; buf.len()];
+            let count = self.inner.read(&mut temp_buffer)?;
+            if count > 0 {
+                // 読み取ったデータをバッファとして保存
+                self.buffer = Some(Cursor::new(temp_buffer));
+                self.read(buf)
+            } else {
+                Ok(0) // EOF
+            }
+        }
+    }
+}
+
+impl<R: Read> Seek for OnetimeRewindableReader<R> {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        match pos {
+            SeekFrom::Start(0) => {
+                if self.has_rewound {
+                    Err(io::Error::new(io::ErrorKind::Other, "Can only rewind once"))
+                } else {
+                    if let Some(ref mut buffer) = self.buffer {
+                        buffer.seek(SeekFrom::Start(0))?;
+                    }
+                    self.has_rewound = true;
+                    Ok(0)
+                }
+            }
+            _ => Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Only seeking to start is supported",
+            )),
+        }
+    }
+}
+
+/*
+// 構造体の定義
+pub struct OnetimeRewindableReader<R: Read> {
+    inner: R,
+    buffer: Cursor<Vec<u8>>,
+    eof: bool,
+}
+
+impl<R: Read> OnetimeRewindableReader<R> {
+    // 新しいBufferedReadSeekを作成
+    pub fn new(inner: R) -> OnetimeRewindableReader<R> {
+        OnetimeRewindableReader {
+            inner,
+            buffer: Cursor::new(Vec::new()),
+            eof: false,
+        }
+    }
+
+    // 内部バッファから読み出す、もしくは必要に応じて入力ソースから読み込む
+    fn fill_buffer(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.eof {
+            return Ok(0);
+        }
+
+        if self.buffer.position() as usize == self.buffer.get_ref().len() {
+            // println!("buffer filled");
+            // println!("buffer prev: {:?}", self.buffer.get_ref());
+            let mut temp_buf = vec![0; buf.len()];
+            let bytes_read = self.inner.read(&mut temp_buf)?;
+            if bytes_read == 0 {
+                self.eof = true; // ファイルの終わりに達したのでフラグをセット
+                return Ok(0);
+            }
+            self.buffer
+                .get_mut()
+                .extend_from_slice(&temp_buf[..bytes_read]);
+            // self.buffer.set_position(0);
+            // println!("buffer afte: {:?}", self.buffer.get_ref());
+            // println!("position: {:?}", self.buffer.position());
+        }
+        self.buffer.read(buf)
+    }
+}
+
+// Readトレイトの実装
+impl<R: Read> Read for OnetimeRewindableReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.fill_buffer(buf)
+    }
+}
+
+// Seekトレイトの実装
+impl<R: Read> Seek for OnetimeRewindableReader<R> {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        self.eof = false;
+        self.buffer.seek(pos)
+    }
+}
+*/

--- a/src/buffered_read_seek.rs
+++ b/src/buffered_read_seek.rs
@@ -1,5 +1,3 @@
-use anyhow::Result;
-use flate2::read::{GzDecoder, ZlibDecoder};
 use std::io::{self, Cursor, Read, Seek, SeekFrom};
 
 pub struct OnetimeRewindableReader<R: Read> {
@@ -66,63 +64,3 @@ impl<R: Read> Seek for OnetimeRewindableReader<R> {
         }
     }
 }
-
-/*
-// 構造体の定義
-pub struct OnetimeRewindableReader<R: Read> {
-    inner: R,
-    buffer: Cursor<Vec<u8>>,
-    eof: bool,
-}
-
-impl<R: Read> OnetimeRewindableReader<R> {
-    // 新しいBufferedReadSeekを作成
-    pub fn new(inner: R) -> OnetimeRewindableReader<R> {
-        OnetimeRewindableReader {
-            inner,
-            buffer: Cursor::new(Vec::new()),
-            eof: false,
-        }
-    }
-
-    // 内部バッファから読み出す、もしくは必要に応じて入力ソースから読み込む
-    fn fill_buffer(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        if self.eof {
-            return Ok(0);
-        }
-
-        if self.buffer.position() as usize == self.buffer.get_ref().len() {
-            // println!("buffer filled");
-            // println!("buffer prev: {:?}", self.buffer.get_ref());
-            let mut temp_buf = vec![0; buf.len()];
-            let bytes_read = self.inner.read(&mut temp_buf)?;
-            if bytes_read == 0 {
-                self.eof = true; // ファイルの終わりに達したのでフラグをセット
-                return Ok(0);
-            }
-            self.buffer
-                .get_mut()
-                .extend_from_slice(&temp_buf[..bytes_read]);
-            // self.buffer.set_position(0);
-            // println!("buffer afte: {:?}", self.buffer.get_ref());
-            // println!("position: {:?}", self.buffer.position());
-        }
-        self.buffer.read(buf)
-    }
-}
-
-// Readトレイトの実装
-impl<R: Read> Read for OnetimeRewindableReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.fill_buffer(buf)
-    }
-}
-
-// Seekトレイトの実装
-impl<R: Read> Seek for OnetimeRewindableReader<R> {
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        self.eof = false;
-        self.buffer.seek(pos)
-    }
-}
-*/

--- a/src/ext_tools.rs
+++ b/src/ext_tools.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use tempfile::{Builder, NamedTempFile, TempDir};
 
 use crate::edam;
-use crate::module::ModuleResult;
+use crate::module::{InvokeOptions, ModuleResult};
 
 const CWL_INSPECTOR_DOCKER_IMAGE: &str = "ghcr.io/tom-tan/cwl-inspector:v0.1.1";
 const LABEL_KEY: &str = "label";
@@ -17,6 +17,7 @@ pub fn invoke(
     cwl_file_path: &Path,
     target_file_path: &Path,
     cwl_input_file_path: &NamedTempFile,
+    options: &InvokeOptions,
 ) -> Result<ModuleResult> {
     info!("Invoking ext_tools {}", cwl_file_path.display());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod args;
+mod buffered_read_seek;
 mod edam;
 mod ext_tools;
 mod fetch;
 mod logger;
 pub mod module;
 mod parser;
+mod source;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use std::fs::File;
 use std::io::BufReader;
+use std::process::exit;
 
 fn main() -> Result<()> {
     // parse arguments and options with clap
@@ -23,6 +24,9 @@ fn main() -> Result<()> {
             })?
         }
     };
+
+    // exit the program with exit code 0
+    // exit(0);
 
     if args.dry_run {
         tataki::module::dry_run(config)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use std::fs::File;
 use std::io::BufReader;
-use std::process::exit;
 
 fn main() -> Result<()> {
     // parse arguments and options with clap

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,14 +1,14 @@
-// mod bam;
-// mod bcf;
-// mod bed;
-// mod cram;
-// mod empty;
-// mod fasta;
+mod bam;
+mod bcf;
+mod bed;
+mod cram;
+mod empty;
+mod fasta;
 mod fastq;
-// mod gff3;
-// mod gtf;
-// mod sam;
-// mod vcf;
+mod gff3;
+mod gtf;
+mod sam;
+mod vcf;
 
 use anyhow::{bail, Result};
 use log::info;
@@ -34,18 +34,18 @@ pub trait Parser {
 pub fn from_str_to_parser(module_name: &str) -> Result<Box<dyn Parser>> {
     let module_name = module_name.to_lowercase();
     match &module_name[..] {
-        // "bam" => Ok(Box::new(bam::Bam)),
-        // "bcf" => Ok(Box::new(bcf::Bcf)),
-        // "bed" => Ok(Box::new(bed::Bed)),
-        // "cram" => Ok(Box::new(cram::Cram)),
-        // "empty" => Ok(Box::new(empty::Empty)),
-        // "fasta" => Ok(Box::new(fasta::Fasta)),
+        "bam" => Ok(Box::new(bam::Bam)),
+        "bcf" => Ok(Box::new(bcf::Bcf)),
+        "bed" => Ok(Box::new(bed::Bed)),
+        "cram" => Ok(Box::new(cram::Cram)),
+        "empty" => Ok(Box::new(empty::Empty)),
+        "fasta" => Ok(Box::new(fasta::Fasta)),
         "fastq" => Ok(Box::new(fastq::Fastq)),
-        // "gff3" => Ok(Box::new(gff3::Gff3)),
-        // "gff" => Ok(Box::new(gff3::Gff3)),
-        // "gtf" => Ok(Box::new(gtf::Gtf)),
-        // "sam" => Ok(Box::new(sam::Sam)),
-        // "vcf" => Ok(Box::new(vcf::Vcf)),
+        "gff3" => Ok(Box::new(gff3::Gff3)),
+        "gff" => Ok(Box::new(gff3::Gff3)),
+        "gtf" => Ok(Box::new(gtf::Gtf)),
+        "sam" => Ok(Box::new(sam::Sam)),
+        "vcf" => Ok(Box::new(vcf::Vcf)),
         _ => bail!("Unsupported parser name: {}", module_name),
     }
 }
@@ -53,7 +53,7 @@ pub fn from_str_to_parser(module_name: &str) -> Result<Box<dyn Parser>> {
 // Return the result of determine() using Ok(ModuleResult), and return errors in other parts using Err.
 pub fn invoke(
     module_name: &str,
-    target_source: &mut Source,
+    target_source: &Source,
     options: &InvokeOptions,
 ) -> Result<ModuleResult> {
     info!("Invoking parser {}", module_name);
@@ -63,10 +63,7 @@ pub fn invoke(
     // Convert Source to readable object
     let target_file_path = match target_source {
         Source::FilePath(target_file_path) => target_file_path,
-        Source::TempFile(target_temp_file) => {
-            let target_file_path = target_temp_file.path();
-            target_file_path
-        }
+        Source::TempFile(target_temp_file) => target_temp_file.path(),
         Source::Stdin => {
             unreachable!()
         }
@@ -97,7 +94,13 @@ mod tests {
         label: &str,
         id: &str,
     ) {
-        let result = invoke(module_name, target_file_path).unwrap();
+        let target_source = Source::FilePath(target_file_path.to_path_buf());
+        let options = InvokeOptions {
+            tidy: true,
+            no_decompress: false,
+            num_records: 100000,
+        };
+        let result = invoke(module_name, &target_source, &options).unwrap();
 
         assert_eq!(result.label(), Some(&label.to_string()));
         assert_eq!(result.id(), Some(&id.to_string()));
@@ -109,7 +112,13 @@ mod tests {
         target_file_path: &Path,
         error_message: &str,
     ) {
-        let result = invoke(module_name, target_file_path).unwrap();
+        let target_source = Source::FilePath(target_file_path.to_path_buf());
+        let options = InvokeOptions {
+            tidy: true,
+            no_decompress: false,
+            num_records: 100000,
+        };
+        let result = invoke(module_name, &target_source, &options).unwrap();
 
         assert_eq!(result.error_message(), Some(&error_message.to_string()));
     }

--- a/src/parser/bam.rs
+++ b/src/parser/bam.rs
@@ -1,17 +1,27 @@
 use std::path::Path;
 
-use crate::module::ModuleResult;
+use crate::module::{InvokeOptions, ModuleResult};
 use crate::parser::Parser;
 
 pub struct Bam;
 
 impl Parser for Bam {
-    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(
+        &self,
+        input_path: &Path,
+        options: &InvokeOptions,
+    ) -> anyhow::Result<ModuleResult> {
         let mut reader = noodles::bam::reader::Builder.build_from_path(input_path)?;
         let header = reader.read_header()?;
-        for result in reader.records(&header) {
+
+        for (count, result) in reader.records(&header).enumerate() {
             #[allow(unused_variables)]
             let record = result?;
+
+            // If the tidy option is not set, the number of lines to read is limited to num_records.
+            if !options.tidy && count + 2 > options.num_records {
+                break;
+            }
         }
         Ok(ModuleResult::with_result(
             Some("BAM".to_string()),

--- a/src/parser/bam.rs
+++ b/src/parser/bam.rs
@@ -6,7 +6,7 @@ use crate::parser::Parser;
 pub struct Bam;
 
 impl Parser for Bam {
-    fn determine(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
         let mut reader = noodles::bam::reader::Builder.build_from_path(input_path)?;
         let header = reader.read_header()?;
         for result in reader.records(&header) {

--- a/src/parser/bcf.rs
+++ b/src/parser/bcf.rs
@@ -6,7 +6,7 @@ use crate::parser::Parser;
 pub struct Bcf;
 
 impl Parser for Bcf {
-    fn determine(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
         let mut reader = noodles::bcf::reader::Builder::default().build_from_path(input_path)?;
 
         let header = reader.read_header()?;

--- a/src/parser/bcf.rs
+++ b/src/parser/bcf.rs
@@ -1,19 +1,28 @@
 use std::path::Path;
 
-use crate::module::ModuleResult;
+use crate::module::{InvokeOptions, ModuleResult};
 use crate::parser::Parser;
 
 pub struct Bcf;
 
 impl Parser for Bcf {
-    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(
+        &self,
+        input_path: &Path,
+        options: &InvokeOptions,
+    ) -> anyhow::Result<ModuleResult> {
         let mut reader = noodles::bcf::reader::Builder::default().build_from_path(input_path)?;
 
         let header = reader.read_header()?;
 
-        for result in reader.records(&header) {
+        for (count, result) in reader.records(&header).enumerate() {
             #[allow(unused_variables)]
             let record = result?;
+
+            // If the tidy option is not set, the number of lines to read is limited to num_records.
+            if !options.tidy && count + 2 > options.num_records {
+                break;
+            }
         }
 
         Ok(ModuleResult::with_result(

--- a/src/parser/bed.rs
+++ b/src/parser/bed.rs
@@ -8,7 +8,7 @@ use crate::parser::Parser;
 pub struct Bed;
 
 impl Parser for Bed {
-    fn determine(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
         let mut reader = File::open(input_path)
             .map(BufReader::new)
             .map(noodles::bed::Reader::new)?;

--- a/src/parser/bed.rs
+++ b/src/parser/bed.rs
@@ -2,20 +2,29 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
-use crate::module::ModuleResult;
+use crate::module::{InvokeOptions, ModuleResult};
 use crate::parser::Parser;
 
 pub struct Bed;
 
 impl Parser for Bed {
-    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(
+        &self,
+        input_path: &Path,
+        options: &InvokeOptions,
+    ) -> anyhow::Result<ModuleResult> {
         let mut reader = File::open(input_path)
             .map(BufReader::new)
             .map(noodles::bed::Reader::new)?;
 
-        for result in reader.records::<3>() {
+        for (count, result) in reader.records::<3>().enumerate() {
             #[allow(unused_variables)]
             let record = result?;
+
+            // If the tidy option is not set, the number of lines to read is limited to num_records.
+            if !options.tidy && count + 2 > options.num_records {
+                break;
+            }
         }
 
         Ok(ModuleResult::with_result(

--- a/src/parser/cram.rs
+++ b/src/parser/cram.rs
@@ -1,19 +1,28 @@
 use std::path::Path;
 
-use crate::module::ModuleResult;
+use crate::module::{InvokeOptions, ModuleResult};
 use crate::parser::Parser;
 
 pub struct Cram;
 
 impl Parser for Cram {
-    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(
+        &self,
+        input_path: &Path,
+        options: &InvokeOptions,
+    ) -> anyhow::Result<ModuleResult> {
         let mut reader = noodles::cram::reader::Builder::default().build_from_path(input_path)?;
 
         let header = reader.read_header()?;
 
-        for result in reader.records(&header) {
+        for (count, result) in reader.records(&header).enumerate() {
             #[allow(unused_variables)]
             let record = result?;
+
+            // If the tidy option is not set, the number of lines to read is limited to num_records.
+            if !options.tidy && count + 2 > options.num_records {
+                break;
+            }
         }
 
         Ok(ModuleResult::with_result(

--- a/src/parser/cram.rs
+++ b/src/parser/cram.rs
@@ -6,7 +6,7 @@ use crate::parser::Parser;
 pub struct Cram;
 
 impl Parser for Cram {
-    fn determine(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
         let mut reader = noodles::cram::reader::Builder::default().build_from_path(input_path)?;
 
         let header = reader.read_header()?;

--- a/src/parser/empty.rs
+++ b/src/parser/empty.rs
@@ -1,14 +1,18 @@
 use std::fs;
 use std::path::Path;
 
-use crate::module::ModuleResult;
+use crate::module::{InvokeOptions, ModuleResult};
 use crate::parser::Parser;
 
 pub struct Empty;
 
 impl Parser for Empty {
     // check if the file is empty or not.
-    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(
+        &self,
+        input_path: &Path,
+        #[allow(unused_variables)] options: &InvokeOptions,
+    ) -> anyhow::Result<ModuleResult> {
         let metadata = fs::metadata(input_path)?;
         if metadata.len() == 0 {
             Ok(ModuleResult::with_result(

--- a/src/parser/empty.rs
+++ b/src/parser/empty.rs
@@ -8,7 +8,7 @@ pub struct Empty;
 
 impl Parser for Empty {
     // check if the file is empty or not.
-    fn determine(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
         let metadata = fs::metadata(input_path)?;
         if metadata.len() == 0 {
             Ok(ModuleResult::with_result(

--- a/src/parser/fasta.rs
+++ b/src/parser/fasta.rs
@@ -1,17 +1,26 @@
 use std::path::Path;
 
-use crate::module::ModuleResult;
+use crate::module::{InvokeOptions, ModuleResult};
 use crate::parser::Parser;
 
 pub struct Fasta;
 
 impl Parser for Fasta {
-    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(
+        &self,
+        input_path: &Path,
+        options: &InvokeOptions,
+    ) -> anyhow::Result<ModuleResult> {
         let mut reader = noodles::fasta::reader::Builder.build_from_path(input_path)?;
 
-        for result in reader.records() {
+        for (count, result) in reader.records().enumerate() {
             #[allow(unused_variables)]
             let record = result?;
+
+            // If the tidy option is not set, the number of lines to read is limited to num_records.
+            if !options.tidy && count + 2 > options.num_records {
+                break;
+            }
         }
 
         Ok(ModuleResult::with_result(

--- a/src/parser/fasta.rs
+++ b/src/parser/fasta.rs
@@ -6,7 +6,7 @@ use crate::parser::Parser;
 pub struct Fasta;
 
 impl Parser for Fasta {
-    fn determine(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
         let mut reader = noodles::fasta::reader::Builder.build_from_path(input_path)?;
 
         for result in reader.records() {

--- a/src/parser/fastq.rs
+++ b/src/parser/fastq.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::BufReader;
 use std::path::Path;
 
 use crate::module::{InvokeOptions, ModuleResult};
@@ -21,8 +21,8 @@ impl Parser for Fastq {
             #[allow(unused_variables)]
             let record = result?;
 
-            // If the tidy option is not set, the number of lines to read is limited to num_lines.
-            if !options.tidy && count >= options.num_lines {
+            // If the tidy option is not set, the number of lines to read is limited to num_records.
+            if !options.tidy && count + 2 > options.num_records {
                 break;
             }
         }

--- a/src/parser/fastq.rs
+++ b/src/parser/fastq.rs
@@ -1,21 +1,30 @@
 use std::fs::File;
-use std::io::BufReader;
+use std::io::{BufRead, BufReader};
 use std::path::Path;
 
-use crate::module::ModuleResult;
+use crate::module::{InvokeOptions, ModuleResult};
 use crate::parser::Parser;
 
 pub struct Fastq;
 
 impl Parser for Fastq {
-    fn determine(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(
+        &self,
+        input_path: &Path,
+        options: &InvokeOptions,
+    ) -> anyhow::Result<ModuleResult> {
         let mut reader = File::open(input_path)
             .map(BufReader::new)
             .map(noodles::fastq::Reader::new)?;
 
-        for result in reader.records() {
+        for (count, result) in reader.records().enumerate() {
             #[allow(unused_variables)]
             let record = result?;
+
+            // If the tidy option is not set, the number of lines to read is limited to num_lines.
+            if !options.tidy && count >= options.num_lines {
+                break;
+            }
         }
 
         Ok(ModuleResult::with_result(

--- a/src/parser/gff3.rs
+++ b/src/parser/gff3.rs
@@ -8,7 +8,7 @@ use crate::parser::Parser;
 pub struct Gff3;
 
 impl Parser for Gff3 {
-    fn determine(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
         let mut reader = File::open(input_path)
             .map(BufReader::new)
             .map(noodles::gff::Reader::new)?;

--- a/src/parser/gff3.rs
+++ b/src/parser/gff3.rs
@@ -2,20 +2,29 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
-use crate::module::ModuleResult;
+use crate::module::{InvokeOptions, ModuleResult};
 use crate::parser::Parser;
 
 pub struct Gff3;
 
 impl Parser for Gff3 {
-    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(
+        &self,
+        input_path: &Path,
+        options: &InvokeOptions,
+    ) -> anyhow::Result<ModuleResult> {
         let mut reader = File::open(input_path)
             .map(BufReader::new)
             .map(noodles::gff::Reader::new)?;
 
-        for result in reader.records() {
+        for (count, result) in reader.records().enumerate() {
             #[allow(unused_variables)]
             let record = result?;
+
+            // If the tidy option is not set, the number of lines to read is limited to num_records.
+            if !options.tidy && count + 2 > options.num_records {
+                break;
+            }
         }
 
         Ok(ModuleResult::with_result(

--- a/src/parser/gtf.rs
+++ b/src/parser/gtf.rs
@@ -8,7 +8,7 @@ use crate::parser::Parser;
 pub struct Gtf;
 
 impl Parser for Gtf {
-    fn determine(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
         let mut reader = File::open(input_path)
             .map(BufReader::new)
             .map(noodles::gtf::Reader::new)?;

--- a/src/parser/gtf.rs
+++ b/src/parser/gtf.rs
@@ -2,20 +2,29 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
-use crate::module::ModuleResult;
+use crate::module::{InvokeOptions, ModuleResult};
 use crate::parser::Parser;
 
 pub struct Gtf;
 
 impl Parser for Gtf {
-    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(
+        &self,
+        input_path: &Path,
+        options: &InvokeOptions,
+    ) -> anyhow::Result<ModuleResult> {
         let mut reader = File::open(input_path)
             .map(BufReader::new)
             .map(noodles::gtf::Reader::new)?;
 
-        for result in reader.records() {
+        for (count, result) in reader.records().enumerate() {
             #[allow(unused_variables)]
             let record = result?;
+
+            // If the tidy option is not set, the number of lines to read is limited to num_records.
+            if !options.tidy && count + 2 > options.num_records {
+                break;
+            }
         }
 
         Ok(ModuleResult::with_result(

--- a/src/parser/sam.rs
+++ b/src/parser/sam.rs
@@ -6,7 +6,7 @@ use crate::parser::Parser;
 pub struct Sam;
 
 impl Parser for Sam {
-    fn determine(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
         let mut reader = noodles::sam::reader::Builder::default().build_from_path(input_path)?;
         let header = reader.read_header()?;
         for result in reader.records(&header) {

--- a/src/parser/sam.rs
+++ b/src/parser/sam.rs
@@ -1,17 +1,26 @@
 use std::path::Path;
 
-use crate::module::ModuleResult;
+use crate::module::{InvokeOptions, ModuleResult};
 use crate::parser::Parser;
 
 pub struct Sam;
 
 impl Parser for Sam {
-    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(
+        &self,
+        input_path: &Path,
+        options: &InvokeOptions,
+    ) -> anyhow::Result<ModuleResult> {
         let mut reader = noodles::sam::reader::Builder::default().build_from_path(input_path)?;
         let header = reader.read_header()?;
-        for result in reader.records(&header) {
+        for (count, result) in reader.records(&header).enumerate() {
             #[allow(unused_variables)]
             let record = result?;
+
+            // If the tidy option is not set, the number of lines to read is limited to num_records.
+            if !options.tidy && count + 2 > options.num_records {
+                break;
+            }
         }
 
         Ok(ModuleResult::with_result(

--- a/src/parser/vcf.rs
+++ b/src/parser/vcf.rs
@@ -6,7 +6,7 @@ use crate::parser::Parser;
 pub struct Vcf;
 
 impl Parser for Vcf {
-    fn determine(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
         let mut reader = noodles::vcf::reader::Builder::default().build_from_path(input_path)?;
 
         let header = reader.read_header()?;

--- a/src/parser/vcf.rs
+++ b/src/parser/vcf.rs
@@ -1,19 +1,28 @@
 use std::path::Path;
 
-use crate::module::ModuleResult;
+use crate::module::{InvokeOptions, ModuleResult};
 use crate::parser::Parser;
 
 pub struct Vcf;
 
 impl Parser for Vcf {
-    fn determine_from_path(&self, input_path: &Path) -> anyhow::Result<ModuleResult> {
+    fn determine_from_path(
+        &self,
+        input_path: &Path,
+        options: &InvokeOptions,
+    ) -> anyhow::Result<ModuleResult> {
         let mut reader = noodles::vcf::reader::Builder::default().build_from_path(input_path)?;
 
         let header = reader.read_header()?;
 
-        for result in reader.records(&header) {
+        for (count, result) in reader.records(&header).enumerate() {
             #[allow(unused_variables)]
             let record = result?;
+
+            // If the tidy option is not set, the number of lines to read is limited to num_records.
+            if !options.tidy && count + 2 > options.num_records {
+                break;
+            }
         }
 
         Ok(ModuleResult::with_result(

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,0 +1,171 @@
+use anyhow::{bail, Result};
+use bzip2::read::BzDecoder;
+use flate2::read::{GzDecoder, ZlibDecoder};
+use nom::bytes;
+use std::fs::File;
+use std::io::{BufRead, BufReader, BufWriter, Read, Seek, Write};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
+use tempfile::{NamedTempFile, TempDir};
+
+use crate::buffered_read_seek::OnetimeRewindableReader;
+use crate::module::InvokeOptions;
+
+static STDIN_IS_USED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug)]
+pub enum Source {
+    FilePath(PathBuf),
+    TempFile(NamedTempFile),
+    Stdin,
+    Memory(Vec<u8>),
+}
+
+impl FromStr for Source {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "-" => {
+                if STDIN_IS_USED.load(std::sync::atomic::Ordering::Relaxed) {
+                    bail!("Only one stdin source is allowed");
+                }
+                STDIN_IS_USED.store(true, std::sync::atomic::Ordering::Relaxed);
+                Ok(Self::Stdin)
+            }
+            _ => Ok(Self::FilePath(PathBuf::from(s))),
+        }
+    }
+}
+
+impl std::fmt::Display for Source {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::FilePath(p) => p.display().fmt(f),
+            Self::TempFile(t) => t.path().display().fmt(f),
+            Self::Stdin => write!(f, "STDIN"),
+            Self::Memory(_) => write!(f, "MEMORY"), // non expected case
+        }
+    }
+}
+
+impl Source {
+    pub fn as_path(&self) -> Option<&PathBuf> {
+        match self {
+            Self::FilePath(p) => Some(p),
+            _ => None,
+        }
+    }
+
+    pub fn as_memory(&self) -> Option<&Vec<u8>> {
+        match self {
+            Self::Memory(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    pub fn convert_into_tempfile_from_file(
+        input_path: &Path,
+        options: &InvokeOptions,
+        temp_dir: &TempDir,
+    ) -> Result<Self> {
+        let file = File::open(input_path)?;
+        Self::convert_into_tempfile(file, options, temp_dir)
+    }
+
+    pub fn convert_into_tempfile_from_stdin(
+        options: &InvokeOptions,
+        temp_dir: &TempDir,
+    ) -> Result<Self> {
+        let stdin = std::io::stdin();
+        let handle = stdin.lock();
+        Self::convert_into_tempfile(handle, options, temp_dir)
+    }
+
+    fn convert_into_tempfile<R: Read>(
+        readable: R,
+        options: &InvokeOptions,
+        temp_dir: &TempDir,
+    ) -> Result<Self> {
+        // create a writer for tempfile
+        let mut tempfile = NamedTempFile::new_in(temp_dir)?;
+        // let mut writer = BufWriter::new(&tempfile);
+
+        let mut tmp_reader = OnetimeRewindableReader::new(readable);
+
+        // read first 10 bytes from reader in order to infer compression format
+        let mut buffer = [0; 100];
+        let bytes_read = tmp_reader.read(&mut buffer)?;
+
+        println!("buffer: {:?}", String::from_utf8(buffer.to_vec()));
+
+        // rewind the reader to the beginning
+        tmp_reader.rewind()?;
+
+        // let mut buffer = [0; 10];
+        // let bytes_read = tmp_reader.read(&mut buffer)?;
+        // println!("buffer: {:?}", String::from_utf8(buffer.to_vec()));
+
+        // let bytes_read = tmp_reader.read(&mut buffer)?;
+        // println!("buffer: {:?}", String::from_utf8(buffer.to_vec()));
+
+        // let bytes_read = tmp_reader.read(&mut buffer)?;
+        // println!("buffer: {:?}", String::from_utf8(buffer.to_vec()));
+        // std::process::exit(1);
+
+        let reader: Box<dyn Read> = if options.no_decompress {
+            Box::new(tmp_reader)
+        } else if let Some(inferred_type) = infer::get(&buffer[..bytes_read]) {
+            let extension = inferred_type.extension();
+            match extension {
+                "gz" => {
+                    // TODO BAMのBGZFがここで誤認されないようにする
+                    let decoder = GzDecoder::new(tmp_reader);
+                    println!("gz!!!");
+                    Box::new(decoder)
+                }
+                "bz2" => {
+                    let decoder = BzDecoder::new(tmp_reader);
+                    println!("bz2!!!");
+                    Box::new(decoder)
+                }
+                _ => {
+                    panic!("Unexpected infer result");
+                }
+            }
+        } else {
+            Box::new(tmp_reader)
+        };
+
+        let mut bufreader = BufReader::new(reader);
+
+        let mut line_buffer = String::new();
+        let mut count = 0;
+        while options.tidy || count < options.num_lines {
+            line_buffer.clear();
+            let bytes_read = bufreader.read_line(&mut line_buffer)?;
+            if bytes_read == 0 {
+                break;
+            }
+            count += 1;
+            // write line into tempfile
+            tempfile.write_all(line_buffer.as_bytes())?;
+        }
+
+        // for (count, line) in bufreader.lines().enumerate() {
+        //     if !options.tidy && count >= options.num_lines {
+        //         break;
+        //     }
+        //     let line = line?;
+        //     // write line into tempfile
+        //     tempfile.write_all(line.as_bytes())?;
+
+        //     // writeln!(writer, "{}", line)?;
+        // }
+
+        println!("tempfile: {:?}", tempfile.path());
+
+        Ok(Self::TempFile(tempfile))
+    }
+}

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,9 +1,8 @@
 use anyhow::{bail, Result};
 use bzip2::read::BzDecoder;
-use flate2::read::{GzDecoder, ZlibDecoder};
-use nom::bytes;
+use flate2::read::GzDecoder;
 use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, Read, Seek, Write};
+use std::io::{BufRead, BufReader, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::atomic::AtomicBool;
@@ -140,9 +139,10 @@ impl Source {
 
         let mut bufreader = BufReader::new(reader);
 
+        // TODO tmpに保存する行数を4倍くらいにする。memo参照
         let mut line_buffer = String::new();
         let mut count = 0;
-        while options.tidy || count < options.num_lines {
+        while options.tidy || count < options.num_records {
             line_buffer.clear();
             let bytes_read = bufreader.read_line(&mut line_buffer)?;
             if bytes_read == 0 {
@@ -154,7 +154,7 @@ impl Source {
         }
 
         // for (count, line) in bufreader.lines().enumerate() {
-        //     if !options.tidy && count >= options.num_lines {
+        //     if !options.tidy && count >= options.num_records {
         //         break;
         //     }
         //     let line = line?;


### PR DESCRIPTION
- Now `tataki` reads 100,000 records by default.
- Specifying `--num-records` can change the number of records to read.
- By setting `--tidy`, you can run the whole scan.